### PR TITLE
No imagemagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,6 @@ disp.println ip_address
 disp.display!
 ```
 
-You can also display monochrome images:
-
-```ruby
-include Magick  # RMagick is a dependency
-image = Image.read("path/to/my/image.png").first # Image.read returns an array
-
-disp.image(image) # Pass in an RMagick image object
-disp.display!
-```
-
 The display can also be easily cleared:
 
 ```ruby

--- a/SSD1306.gemspec
+++ b/SSD1306.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
 
   spec.add_runtime_dependency "i2c", ">= 0.4.0"
-  spec.add_runtime_dependency "rmagick", "~> 2.14"
 end

--- a/lib/SSD1306.rb
+++ b/lib/SSD1306.rb
@@ -1,5 +1,4 @@
 require 'i2c'
-require 'rmagick'
 
 require 'SSD1306/version'
 require 'SSD1306/font'

--- a/lib/SSD1306/display.rb
+++ b/lib/SSD1306/display.rb
@@ -144,23 +144,6 @@ module SSD1306
       @interface.write @address, control, @buffer.pack('c*')
     end
 
-    def image(image)
-      image.image_type = BilevelType
-      pix = image.export_pixels(0, 0, @width, @height, 'I')
-      index = 0
-      for page in 0...@pages
-        for x in 0...@width
-          bits = 0
-          for bit in [0, 1, 2, 3, 4, 5, 6, 7]
-            bits = bits << 1
-            bits |= pix[(page*8*@width) + x + ((7-bit)*@width)] == 0 ? 0 : 1
-          end
-          @buffer[index] = bits
-          index += 1
-        end
-      end
-    end
-
     def clear
       @buffer = [0]*(@width*@pages)
       @cursor.reset

--- a/lib/SSD1306/display.rb
+++ b/lib/SSD1306/display.rb
@@ -204,12 +204,13 @@ module SSD1306
       # dim = true: display is dimmed
       # dim = false: display is normal
       contrast = 0 # assume dim
-      if not dim
+      unless dim
         if @vccstate == SSD1306_EXTERNALVCC
           contrast = 0x9F
         else
           contrast = 0xCF
         end
+      end
       self.command SSD1306_SETCONTRAST
       self.command contrast
     end

--- a/lib/SSD1306/display.rb
+++ b/lib/SSD1306/display.rb
@@ -200,9 +200,23 @@ module SSD1306
     end
 
     # TODO: Implement Dimming functionality
+    # Dim the display
+    # dim = true: display is dimmed
+    # dim = false: display is normal
     def dim(dim)
-      raise 'Dim not implemented yet'
+      # raise 'Dim not implemented yet'
+      if dim
+        contrast = 0
+      elsif @vccstate == SSD1306_EXTERNALVCC
+        contrast = 0x9F
+      else
+        contrast = 0xCF
+      end
+      puts contrast
+      self.command SSD1306_SETCONTRAST
+      self.command contrast
     end
+
 
     protected
 

--- a/lib/SSD1306/display.rb
+++ b/lib/SSD1306/display.rb
@@ -199,20 +199,17 @@ module SSD1306
       raise 'Contrast not yet implemented'
     end
 
-    # TODO: Implement Dimming functionality
     # Dim the display
-    # dim = true: display is dimmed
-    # dim = false: display is normal
     def dim(dim)
-      # raise 'Dim not implemented yet'
-      if dim
-        contrast = 0
-      elsif @vccstate == SSD1306_EXTERNALVCC
-        contrast = 0x9F
-      else
-        contrast = 0xCF
-      end
-      puts contrast
+      # dim = true: display is dimmed
+      # dim = false: display is normal
+      contrast = 0 # assume dim
+      if not dim
+        if @vccstate == SSD1306_EXTERNALVCC
+          contrast = 0x9F
+        else
+          contrast = 0xCF
+        end
       self.command SSD1306_SETCONTRAST
       self.command contrast
     end

--- a/lib/SSD1306/version.rb
+++ b/lib/SSD1306/version.rb
@@ -1,3 +1,3 @@
 module SSD1306
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
Remove rmagick dependencies (and through that, dependences on imagemagick). Should no be able to install on raspberry pi without needing to install any .debs first.